### PR TITLE
fix: 下载文件时转义文件中的保留字符

### DIFF
--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -131,7 +131,7 @@ export function trimHash(url: string) {
 }
 
 export function escapeCharacter(str?: string) {
-    return str !== undefined ? `${str}`.replace(/\//g, '_') : '';
+    return str !== undefined ? `${str}`.replace(/[\/|\\?*"<>:]+/g, '_') : '';
 }
 
 export function getDirectory(dirPath: string) {


### PR DESCRIPTION
参考：[维基百科-文件名](https://zh.wikipedia.org/wiki/%E6%AA%94%E6%A1%88%E5%90%8D%E7%A8%B1)

~致敬传奇社团 [＿bazaar records](https://thwiki.cc/%EF%BC%BFbazaar_records) / [.new label](https://thwiki.cc/.new_label) 的曲名~