### PR TITLE
feat: 增加 Android Auto 媒体播放支持

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,5 +187,6 @@ dependencies {
     // https://mvnrepository.com/artifact/net.jthink/jaudiotagger
     implementation 'net.jthink:jaudiotagger:2.2.5'
     implementation 'androidx.core:core-splashscreen:1.0.0'
+    implementation 'androidx.media:media:1.7.0'
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="fun.upup.musicfree">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="fun.upup.musicfree">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -22,6 +24,19 @@
       android:usesCleartextTraffic="true"
       android:extractNativeLibs="true"
     >
+      <meta-data
+        android:name="com.google.android.gms.car.application"
+        android:resource="@xml/automotive_app_desc" />
+
+      <service
+        android:name=".AutoMediaBrowserService"
+        android:enabled="true"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="android.media.browse.MediaBrowserService" />
+        </intent-filter>
+      </service>
+
       <activity
         android:name=".MainActivity"
         android:theme="@style/Theme.App.SplashScreen"
@@ -40,7 +55,8 @@
               <category android:name="android.intent.category.BROWSABLE" />
               <data android:scheme="musicfree" android:host="app"/>
               <data android:scheme="musicfree" android:host="install"/>
-          </intent-filter>          
+              <data android:scheme="musicfree" android:host="auto"/>
+          </intent-filter>
           <!-- 处理音频文件 -->
           <intent-filter>
               <action android:name="android.intent.action.VIEW" />

--- a/android/app/src/main/java/fun/upup/musicfree/AutoMediaBrowserService.kt
+++ b/android/app/src/main/java/fun/upup/musicfree/AutoMediaBrowserService.kt
@@ -1,0 +1,537 @@
+package `fun`.upup.musicfree
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.FileObserver
+import android.os.Handler
+import android.os.Looper
+import android.support.v4.media.MediaBrowserCompat
+import android.support.v4.media.MediaBrowserCompat.MediaItem
+import android.support.v4.media.MediaDescriptionCompat
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import androidx.media.MediaBrowserServiceCompat
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+class AutoMediaBrowserService : MediaBrowserServiceCompat() {
+    private lateinit var mediaSession: MediaSessionCompat
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var currentMediaId: String? = null
+    private var artworkLoadVersion = 0
+    private var catalogObserver: FileObserver? = null
+    private val catalogRefreshRunnable = Runnable {
+        notifyChildrenChanged(ROOT_ID)
+        notifyChildrenChanged(QUEUE_ID)
+        refreshMetadataFromCatalog()
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val session = MediaSessionCompat(this, "MusicFreeAndroidAuto")
+        session.setFlags(
+            MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS or
+                MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS,
+        )
+        session.setCallback(object : MediaSessionCompat.Callback() {
+                override fun onPlay() {
+                    resumePlayback()
+                }
+
+                override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) {
+                    playMediaId(mediaId)
+                }
+
+                override fun onPlayFromSearch(query: String?, extras: Bundle?) {
+                    val normalizedQuery = query?.trim()?.lowercase().orEmpty()
+                    if (normalizedQuery.isBlank()) {
+                        resumePlayback()
+                        return
+                    }
+
+                    val item = readCatalog().items.firstOrNull {
+                        it.title.lowercase().contains(normalizedQuery) ||
+                            it.artist.lowercase().contains(normalizedQuery) ||
+                            it.album.lowercase().contains(normalizedQuery)
+                    }
+                    playMediaId(item?.mediaId)
+                }
+
+                override fun onPause() {
+                    if (sendAutoCommand("pause")) {
+                        session.setPlaybackState(playbackState(PlaybackStateCompat.STATE_PAUSED))
+                    }
+                }
+
+                override fun onStop() {
+                    if (sendAutoCommand("pause")) {
+                        session.setPlaybackState(playbackState(PlaybackStateCompat.STATE_STOPPED))
+                    }
+                }
+
+                override fun onSeekTo(pos: Long) {
+                    val positionSeconds = (pos / 1000L).coerceAtLeast(0L)
+                    if (sendAutoCommand("seek", positionSeconds = positionSeconds)) {
+                        session.setPlaybackState(playbackState(PlaybackStateCompat.STATE_PLAYING, pos))
+                    }
+                }
+
+                override fun onSkipToNext() {
+                    playAdjacent(1, "next", PlaybackStateCompat.STATE_SKIPPING_TO_NEXT)
+                }
+
+                override fun onSkipToPrevious() {
+                    playAdjacent(-1, "previous", PlaybackStateCompat.STATE_SKIPPING_TO_PREVIOUS)
+                }
+            })
+        session.setPlaybackState(playbackState(PlaybackStateCompat.STATE_NONE))
+        session.isActive = true
+        mediaSession = session
+        sessionToken = mediaSession.sessionToken
+        startCatalogObserver()
+
+        readCatalog().let { catalog ->
+            currentMediaId = catalog.currentMediaId
+            catalog.items.firstOrNull { it.mediaId == catalog.currentMediaId }?.let(::updateMetadata)
+            applyPlaybackState(catalog.playbackState)
+        }
+    }
+
+    override fun onDestroy() {
+        catalogObserver?.stopWatching()
+        catalogObserver = null
+        mainHandler.removeCallbacksAndMessages(null)
+        mediaSession.release()
+        super.onDestroy()
+    }
+
+    override fun onGetRoot(
+        clientPackageName: String,
+        clientUid: Int,
+        rootHints: Bundle?,
+    ): BrowserRoot {
+        return BrowserRoot(ROOT_ID, null)
+    }
+
+    override fun onLoadChildren(
+        parentId: String,
+        result: Result<MutableList<MediaBrowserCompat.MediaItem>>,
+    ) {
+        result.sendResult(
+            when (parentId) {
+                ROOT_ID -> rootItems()
+                QUEUE_ID -> readCatalog().items.map { it.toMediaItem() }.toMutableList()
+                else -> mutableListOf()
+            },
+        )
+    }
+
+    private fun rootItems(): MutableList<MediaBrowserCompat.MediaItem> {
+        val catalog = readCatalog()
+        val items = mutableListOf<MediaBrowserCompat.MediaItem>()
+
+        catalog.currentMediaId?.let { currentMediaId ->
+            val currentItem = catalog.items.firstOrNull { it.mediaId == currentMediaId }
+            items += currentItem?.toMediaItem() ?: mediaItem(
+                    mediaId = currentMediaId,
+                    title = "Resume playback",
+                    subtitle = getString(R.string.app_name),
+                    browsable = false,
+                )
+        }
+
+        items += mediaItem(
+            mediaId = QUEUE_ID,
+            title = "当前列表",
+            subtitle = "${catalog.items.size} 首歌曲",
+            browsable = true,
+        )
+
+        if (catalog.items.isEmpty()) {
+            items += mediaItem(
+                mediaId = EMPTY_ID,
+                title = getString(R.string.app_name),
+                subtitle = "Open MusicFree on your phone and start a playlist first",
+                browsable = false,
+            )
+        }
+
+        return items
+    }
+
+    private fun mediaItem(
+        mediaId: String,
+        title: String,
+        subtitle: String?,
+        browsable: Boolean,
+        descriptionText: String? = null,
+        iconUri: Uri? = null,
+    ): MediaBrowserCompat.MediaItem {
+        val description = MediaDescriptionCompat.Builder()
+            .setMediaId(mediaId)
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setDescription(descriptionText)
+            .setIconUri(iconUri)
+            .build()
+
+        return MediaItem(
+            description,
+            if (browsable) MediaItem.FLAG_BROWSABLE else MediaItem.FLAG_PLAYABLE,
+        )
+    }
+
+    private fun CatalogItem.toMediaItem(): MediaBrowserCompat.MediaItem {
+        val description = MediaDescriptionCompat.Builder()
+            .setMediaId(mediaId)
+            .setTitle(title)
+            .setSubtitle(artist)
+            .setDescription(album)
+            .setIconUri(artworkUri())
+            .build()
+
+        return MediaItem(description, MediaItem.FLAG_PLAYABLE)
+    }
+
+    private fun playMediaId(mediaId: String?) {
+        if (mediaId.isNullOrBlank() || mediaId == EMPTY_ID || mediaId == QUEUE_ID) {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_NONE))
+            return
+        }
+
+        val item = readCatalog().items.firstOrNull { it.mediaId == mediaId }
+        item?.let(::updateMetadata)
+        mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_BUFFERING))
+
+        if (sendAutoCommand("play", mediaId)) {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_PLAYING))
+            scheduleMetadataRefresh()
+        } else {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_ERROR))
+        }
+    }
+
+    private fun resumePlayback() {
+        val catalog = readCatalog()
+        val mediaId = currentMediaId ?: catalog.currentMediaId
+        catalog.items.firstOrNull { it.mediaId == mediaId }?.let(::updateMetadata)
+        if (sendAutoCommand("play")) {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_PLAYING))
+            scheduleMetadataRefresh()
+        }
+    }
+
+    private fun playAdjacent(offset: Int, command: String, transitionState: Int) {
+        val catalog = readCatalog()
+        if (catalog.items.isEmpty()) {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_NONE))
+            return
+        }
+
+        val mediaId = currentMediaId ?: catalog.currentMediaId
+        val currentIndex = catalog.items.indexOfFirst { it.mediaId == mediaId }.takeIf { it >= 0 } ?: 0
+        val targetIndex = (currentIndex + offset + catalog.items.size) % catalog.items.size
+        updateMetadata(catalog.items[targetIndex])
+
+        mediaSession.setPlaybackState(playbackState(transitionState))
+        if (sendAutoCommand(command)) {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_PLAYING))
+            scheduleMetadataRefresh()
+        } else {
+            mediaSession.setPlaybackState(playbackState(PlaybackStateCompat.STATE_ERROR))
+        }
+    }
+
+    private fun scheduleMetadataRefresh() {
+        mainHandler.postDelayed({ refreshMetadataFromCatalog() }, 500)
+        mainHandler.postDelayed({ refreshMetadataFromCatalog() }, 1500)
+    }
+
+    private fun startCatalogObserver() {
+        val file = catalogFile()
+        val directory = file.parentFile ?: return
+        directory.mkdirs()
+
+        catalogObserver = object : FileObserver(
+            directory.absolutePath,
+            FileObserver.CLOSE_WRITE or
+                FileObserver.MOVED_TO or
+                FileObserver.CREATE or
+                FileObserver.MODIFY,
+        ) {
+            override fun onEvent(event: Int, path: String?) {
+                if (path != file.name) {
+                    return
+                }
+
+                mainHandler.removeCallbacks(catalogRefreshRunnable)
+                mainHandler.postDelayed(catalogRefreshRunnable, 100)
+            }
+        }
+        catalogObserver?.startWatching()
+    }
+
+    private fun refreshMetadataFromCatalog() {
+        val catalog = readCatalog()
+        val targetMediaId = catalog.currentMediaId ?: currentMediaId
+        catalog.items.firstOrNull { it.mediaId == targetMediaId }?.let(::updateMetadata)
+        applyPlaybackState(catalog.playbackState)
+    }
+
+    private fun applyPlaybackState(stateName: String?) {
+        val state = when (stateName) {
+            "playing" -> PlaybackStateCompat.STATE_PLAYING
+            "paused", "ready" -> PlaybackStateCompat.STATE_PAUSED
+            "stopped", "none", "ended" -> PlaybackStateCompat.STATE_STOPPED
+            "loading", "buffering" -> PlaybackStateCompat.STATE_BUFFERING
+            "error" -> PlaybackStateCompat.STATE_ERROR
+            else -> return
+        }
+        mediaSession.setPlaybackState(playbackState(state))
+    }
+
+    private fun updateMetadata(item: CatalogItem) {
+        currentMediaId = item.mediaId
+        val builder = metadataBuilder(item)
+        mediaSession.setMetadata(builder.build())
+        loadArtworkAsync(item)
+    }
+
+    private fun metadataBuilder(item: CatalogItem, artwork: Bitmap? = null): MediaMetadataCompat.Builder {
+        val builder = MediaMetadataCompat.Builder()
+            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, item.title)
+            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, item.artist)
+            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, item.album)
+            .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, item.title)
+            .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_SUBTITLE, item.artist)
+            .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION, item.album)
+            .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, item.duration * 1000L)
+
+        val artworkUri = item.normalizedArtwork()
+        if (artworkUri != null) {
+            builder
+                .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, artworkUri)
+                .putString(MediaMetadataCompat.METADATA_KEY_ART_URI, artworkUri)
+                .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI, artworkUri)
+        }
+
+        if (artwork != null) {
+            builder
+                .putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, artwork)
+                .putBitmap(MediaMetadataCompat.METADATA_KEY_ART, artwork)
+                .putBitmap(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON, artwork)
+        }
+
+        return builder
+    }
+
+    private fun loadArtworkAsync(item: CatalogItem) {
+        val artwork = item.normalizedArtwork() ?: return
+        if (artwork.isBlank()) {
+            return
+        }
+
+        val expectedMediaId = item.mediaId
+        val version = ++artworkLoadVersion
+        Thread {
+            val bitmap = loadArtworkBitmap(artwork) ?: return@Thread
+            mainHandler.post {
+                if (currentMediaId == expectedMediaId && version == artworkLoadVersion) {
+                    mediaSession.setMetadata(metadataBuilder(item, bitmap).build())
+                }
+            }
+        }.start()
+    }
+
+    private fun loadArtworkBitmap(artwork: String): Bitmap? {
+        return runCatching {
+            val uri = Uri.parse(artwork)
+            val rawBitmap = when (uri.scheme?.lowercase()) {
+                "http", "https" -> {
+                    val connection = URL(artwork).openConnection()
+                    connection.connectTimeout = 3000
+                    connection.readTimeout = 5000
+                    connection.setRequestProperty("User-Agent", ARTWORK_USER_AGENT)
+                    connection.setRequestProperty("Accept", "image/webp,image/apng,image/*,*/*;q=0.8")
+                    if (connection is HttpURLConnection) {
+                        connection.instanceFollowRedirects = true
+                    }
+                    connection.getInputStream().use(BitmapFactory::decodeStream)
+                }
+                "file" -> BitmapFactory.decodeFile(uri.path)
+                "content" -> contentResolver.openInputStream(uri)?.use(BitmapFactory::decodeStream)
+                else -> BitmapFactory.decodeFile(artwork)
+            } ?: return null
+
+            scaleArtwork(rawBitmap)
+        }.getOrNull()
+    }
+
+    private fun scaleArtwork(bitmap: Bitmap): Bitmap {
+        val maxSize = 512
+        if (bitmap.width <= maxSize && bitmap.height <= maxSize) {
+            return bitmap
+        }
+
+        val scale = minOf(maxSize.toFloat() / bitmap.width, maxSize.toFloat() / bitmap.height)
+        return Bitmap.createScaledBitmap(
+            bitmap,
+            (bitmap.width * scale).toInt().coerceAtLeast(1),
+            (bitmap.height * scale).toInt().coerceAtLeast(1),
+            true,
+        )
+    }
+
+    private fun CatalogItem.artworkUri(): Uri? {
+        return normalizedArtwork()
+            ?.let { runCatching { Uri.parse(it) }.getOrNull() }
+    }
+
+    private fun CatalogItem.normalizedArtwork(): String? {
+        val trimmedArtwork = artwork.trim().takeIf { it.isNotBlank() } ?: return null
+        return if (trimmedArtwork.startsWith("//")) {
+            "https:$trimmedArtwork"
+        } else {
+            trimmedArtwork
+        }
+    }
+
+    private fun sendAutoCommand(
+        command: String,
+        mediaId: String? = null,
+        positionSeconds: Long? = null,
+    ): Boolean {
+        return runCatching {
+            writePendingCommand(command, mediaId, positionSeconds)
+            startTrackPlayerService()
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun writePendingCommand(
+        command: String,
+        mediaId: String?,
+        positionSeconds: Long?,
+    ) {
+        val file = commandFile()
+        file.parentFile?.mkdirs()
+        val json = JSONObject()
+            .put("id", System.currentTimeMillis())
+            .put("command", command)
+            .put("mediaId", mediaId ?: JSONObject.NULL)
+            .put("position", positionSeconds ?: JSONObject.NULL)
+        file.writeText(json.toString())
+    }
+
+    private fun startTrackPlayerService() {
+        val intent = Intent().setClassName(
+            packageName,
+            "com.doublesymmetry.trackplayer.service.MusicService",
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
+    }
+
+    private fun playbackState(
+        state: Int,
+        positionMs: Long = PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN,
+    ): PlaybackStateCompat {
+        val speed = if (state == PlaybackStateCompat.STATE_PLAYING) 1f else 0f
+        return PlaybackStateCompat.Builder()
+            .setActions(
+                PlaybackStateCompat.ACTION_PLAY or
+                    PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID or
+                    PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH or
+                    PlaybackStateCompat.ACTION_PAUSE or
+                    PlaybackStateCompat.ACTION_STOP or
+                    PlaybackStateCompat.ACTION_SEEK_TO or
+                    PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+                    PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS,
+            )
+            .setState(state, positionMs, speed)
+            .build()
+    }
+
+    private fun catalogFile(): File {
+        val baseDir = getExternalFilesDir(null) ?: filesDir
+        return File(baseDir, "data/android_auto_catalog.json")
+    }
+
+    private fun commandFile(): File {
+        val baseDir = getExternalFilesDir(null) ?: filesDir
+        return File(baseDir, "data/android_auto_command.json")
+    }
+
+    private fun readCatalog(): Catalog {
+        val file = catalogFile()
+        if (!file.exists()) {
+            return Catalog()
+        }
+
+        return runCatching {
+            val json = JSONObject(file.readText())
+            val items = json.optJSONArray("items").orEmpty().mapNotNull { raw ->
+                (raw as? JSONObject)?.let {
+                    CatalogItem(
+                        mediaId = it.optString("mediaId"),
+                        title = it.optString("title", getString(R.string.app_name)),
+                        artist = it.optString("artist"),
+                        album = it.optString("album"),
+                        artwork = it.optString("artwork"),
+                        duration = it.optLong("duration", 0L),
+                    )
+                }
+            }.filter { it.mediaId.isNotBlank() }
+
+            Catalog(
+                currentMediaId = json.optString("currentMediaId").takeIf { it.isNotBlank() && it != "null" },
+                playbackState = json.optString("playbackState").takeIf { it.isNotBlank() && it != "null" },
+                items = items,
+            )
+        }.getOrElse {
+            Catalog()
+        }
+    }
+
+    private fun JSONArray?.orEmpty(): List<Any?> {
+        if (this == null) {
+            return emptyList()
+        }
+        return List(length()) { index -> opt(index) }
+    }
+
+    private data class Catalog(
+        val currentMediaId: String? = null,
+        val playbackState: String? = null,
+        val items: List<CatalogItem> = emptyList(),
+    )
+
+    private data class CatalogItem(
+        val mediaId: String,
+        val title: String,
+        val artist: String,
+        val album: String,
+        val artwork: String,
+        val duration: Long,
+    )
+
+    companion object {
+        private const val ROOT_ID = "musicfree_root"
+        private const val QUEUE_ID = "musicfree_queue"
+        private const val EMPTY_ID = "musicfree_empty"
+        private const val ARTWORK_USER_AGENT =
+            "Mozilla/5.0 (Linux; Android) AppleWebKit/537.36 (KHTML, like Gecko) MusicFree/AndroidAuto"
+    }
+}

--- a/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media" />
+</automotiveApp>

--- a/src/core/trackPlayer/index.ts
+++ b/src/core/trackPlayer/index.ts
@@ -39,6 +39,7 @@ import minDistance from "@/utils/minDistance";
 import { IPluginManager } from "@/types/core/pluginManager";
 import { ImgAsset } from "@/constants/assetsConst";
 import { resolveImportedAssetOrPath } from "@/utils/fileUtils";
+import { exportAndroidAutoCatalog } from "@/utils/androidAutoCatalog";
 
 
 
@@ -598,6 +599,7 @@ class TrackPlayer extends EventEmitter<{
                     0,
                     mergedTrack as TrackMetadataBase,
                 );
+                exportAndroidAutoCatalog(this.playList, mergedTrack as IMusic.IMusicItem);
             }
         } catch (e: any) {
             const message = e?.message;
@@ -750,6 +752,7 @@ class TrackPlayer extends EventEmitter<{
             getDefaultStore().set(currentMusicAtom, null);
             PersistStatus.set("music.musicItem", undefined);
             PersistStatus.set("music.progress", 0);
+            exportAndroidAutoCatalog(this.playList, null);
 
             this.emit(TrackPlayerEvents.CurrentMusicChanged, null);
             return;
@@ -759,6 +762,7 @@ class TrackPlayer extends EventEmitter<{
         }
         this.currentIndex = this.getMusicIndexInPlayList(musicItem);
         getDefaultStore().set(currentMusicAtom, musicItem);
+        exportAndroidAutoCatalog(this.playList, musicItem);
 
         this.emit(TrackPlayerEvents.CurrentMusicChanged, musicItem);
     }
@@ -825,6 +829,7 @@ class TrackPlayer extends EventEmitter<{
         }
 
         this.currentIndex = this.getMusicIndexInPlayList(this.currentMusic);
+        exportAndroidAutoCatalog(newPlayList, this.currentMusic);
     }
 
 

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -3,10 +3,163 @@ import RNTrackPlayer, { Event, State } from "react-native-track-player";
 import TrackPlayer from "@/core/trackPlayer";
 import { musicIsPaused } from "@/utils/trackUtils";
 import PersistStatus from "@/utils/persistStatus";
+import {
+    androidAutoCommandPath,
+    exportAndroidAutoPlaybackState,
+    getAndroidAutoMediaId,
+} from "@/utils/androidAutoCatalog";
+import { readFile, unlink } from "react-native-fs";
+import { getDefaultStore } from "jotai";
+import bootstrapAtom from "@/entry/bootstrap/bootstrap.atom";
 
 let resumeState: State | null;
+
+type PendingAndroidAutoCommand = {
+    id?: number;
+    command?: string;
+    mediaId?: string | null;
+    position?: number | null;
+};
+
+function delay(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function playFirstAvailableTrack() {
+    const target = TrackPlayer.currentMusic ?? TrackPlayer.playList[0];
+    if (target) {
+        return TrackPlayer.play(target, true);
+    }
+    return TrackPlayer.play();
+}
+
+function matchesSearchTerm(musicItem: IMusic.IMusicItem, rawTerm?: string) {
+    const term = rawTerm?.trim().toLowerCase();
+    if (!term) {
+        return false;
+    }
+    return [musicItem.title, musicItem.artist, musicItem.album]
+        .filter(Boolean)
+        .some(value => value.toString().toLowerCase().includes(term));
+}
+
+function safeDecodeURIComponent(value: string) {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+function matchesMediaId(musicItem: IMusic.IMusicItem, rawMediaId?: string) {
+    if (!rawMediaId) {
+        return false;
+    }
+
+    const decodedMediaId = safeDecodeURIComponent(rawMediaId);
+    return (
+        getAndroidAutoMediaId(musicItem) === rawMediaId ||
+        getAndroidAutoMediaId(musicItem) === decodedMediaId ||
+        musicItem.id === rawMediaId ||
+        `${musicItem.platform}:${musicItem.id}` === rawMediaId ||
+        musicItem.id === decodedMediaId ||
+        `${musicItem.platform}:${musicItem.id}` === decodedMediaId
+    );
+}
+
+async function waitForBootstrapReady() {
+    for (let i = 0; i < 20; ++i) {
+        const bootstrapState = getDefaultStore().get(bootstrapAtom).state;
+        if (
+            bootstrapState === "Done" ||
+            bootstrapState === "TrackPlayerError" ||
+            bootstrapState === "Fatal"
+        ) {
+            return;
+        }
+        if (TrackPlayer.currentMusic || TrackPlayer.playList.length) {
+            return;
+        }
+        await delay(500);
+    }
+}
+
+async function readPendingAndroidAutoCommand() {
+    try {
+        const raw = await readFile(androidAutoCommandPath, "utf8");
+        await unlink(androidAutoCommandPath).catch(() => undefined);
+        const command = JSON.parse(raw) as PendingAndroidAutoCommand;
+        if (!command?.command) {
+            return null;
+        }
+        if (command.id && Date.now() - command.id > 120000) {
+            return null;
+        }
+        return command;
+    } catch {
+        return null;
+    }
+}
+
+async function handlePendingAndroidAutoCommand() {
+    const command = await readPendingAndroidAutoCommand();
+    if (!command) {
+        return;
+    }
+
+    await waitForBootstrapReady();
+
+    if (command.command === "next") {
+        return TrackPlayer.skipToNext();
+    }
+    if (command.command === "previous") {
+        return TrackPlayer.skipToPrevious();
+    }
+    if (command.command === "pause") {
+        return TrackPlayer.pause();
+    }
+    if (command.command === "seek") {
+        const position = Number(command.position);
+        if (Number.isFinite(position)) {
+            return TrackPlayer.seekTo(position);
+        }
+        return;
+    }
+    if (command.command === "play") {
+        const target = TrackPlayer.playList.find(item =>
+            matchesMediaId(item, command.mediaId ?? undefined),
+        );
+        if (target) {
+            return TrackPlayer.play(target, true);
+        }
+        return playFirstAvailableTrack();
+    }
+}
+
 module.exports = async function () {
     RNTrackPlayer.addEventListener(Event.RemotePlay, () => TrackPlayer.play());
+    RNTrackPlayer.addEventListener(Event.RemotePlayId, ({ id }) => {
+        const target = TrackPlayer.playList.find(item => matchesMediaId(item, id));
+        if (target) {
+            return TrackPlayer.play(target, true);
+        }
+        return playFirstAvailableTrack();
+    });
+    RNTrackPlayer.addEventListener(Event.RemotePlaySearch, event => {
+        const target =
+            TrackPlayer.playList.find(item =>
+                matchesSearchTerm(item, event.query) ||
+                matchesSearchTerm(item, event.title) ||
+                matchesSearchTerm(item, event.artist) ||
+                matchesSearchTerm(item, event.album) ||
+                matchesSearchTerm(item, event.genre) ||
+                matchesSearchTerm(item, event.playlist),
+            ) ?? null;
+        if (target) {
+            return TrackPlayer.play(target, true);
+        }
+        return playFirstAvailableTrack();
+    });
     RNTrackPlayer.addEventListener(Event.RemotePause, () =>
         TrackPlayer.pause(),
     );
@@ -59,6 +212,10 @@ module.exports = async function () {
         PersistStatus.set("music.progress", evt.position);
     });
 
+    RNTrackPlayer.addEventListener(Event.PlaybackState, evt => {
+        exportAndroidAutoPlaybackState(evt.state);
+    });
+
     RNTrackPlayer.addEventListener(Event.RemoteStop, async () => {
         RNTrackPlayer.stop();
     });
@@ -66,4 +223,6 @@ module.exports = async function () {
     RNTrackPlayer.addEventListener(Event.RemoteSeek, async evt => {
         TrackPlayer.seekTo(evt.position);
     });
+
+    handlePendingAndroidAutoCommand().catch(() => undefined);
 };

--- a/src/utils/androidAutoCatalog.ts
+++ b/src/utils/androidAutoCatalog.ts
@@ -1,0 +1,102 @@
+import pathConst from "@/constants/pathConst";
+import { safeStringify } from "@/utils/jsonUtil";
+import { writeFile } from "react-native-fs";
+
+type AndroidAutoCatalogItem = {
+    mediaId: string;
+    id: string;
+    platform: string;
+    title: string;
+    artist?: string;
+    album?: string;
+    artwork?: string;
+    duration?: number;
+};
+
+export const androidAutoCatalogPath = `${pathConst.dataPath}android_auto_catalog.json`;
+export const androidAutoCommandPath = `${pathConst.dataPath}android_auto_command.json`;
+
+let catalogExportTask: Promise<void> = Promise.resolve();
+let lastPlayList: IMusic.IMusicItem[] = [];
+let lastCurrentMusic: IMusic.IMusicItem | null = null;
+let lastPlaybackState: string | null = null;
+let hasCatalogSnapshot = false;
+
+export function getAndroidAutoMediaId(musicItem: IMusic.IMusicItem) {
+    return `${encodeURIComponent(musicItem.platform)}:${encodeURIComponent(musicItem.id)}`;
+}
+
+function getCatalogArtwork(artwork: unknown) {
+    if (typeof artwork !== "string") {
+        return undefined;
+    }
+    const trimmedArtwork = artwork.trim();
+    return trimmedArtwork.length ? trimmedArtwork : undefined;
+}
+
+function toCatalogItem(musicItem: IMusic.IMusicItem): AndroidAutoCatalogItem {
+    const artwork = getCatalogArtwork(musicItem.artwork);
+    return {
+        mediaId: getAndroidAutoMediaId(musicItem),
+        id: musicItem.id,
+        platform: musicItem.platform,
+        title: musicItem.title,
+        artist: musicItem.artist,
+        album: musicItem.album,
+        ...(artwork ? { artwork } : {}),
+        duration: musicItem.duration,
+    };
+}
+
+function writeAndroidAutoCatalog() {
+    const currentMediaId = lastCurrentMusic ? getAndroidAutoMediaId(lastCurrentMusic) : null;
+    const items: AndroidAutoCatalogItem[] = lastPlayList.slice(0, 500).map(item => {
+        const mediaId = getAndroidAutoMediaId(item);
+        return toCatalogItem(
+            lastCurrentMusic && mediaId === currentMediaId
+                ? {
+                    ...item,
+                    ...lastCurrentMusic,
+                    id: item.id,
+                    platform: item.platform,
+                }
+                : item,
+        );
+    });
+
+    if (
+        lastCurrentMusic &&
+        !items.some(item => item.mediaId === currentMediaId)
+    ) {
+        items.unshift(toCatalogItem(lastCurrentMusic));
+        items.splice(500);
+    }
+
+    const catalogJson = safeStringify({
+        currentMediaId,
+        playbackState: lastPlaybackState,
+        items,
+    });
+
+    catalogExportTask = catalogExportTask
+        .catch(() => undefined)
+        .then(() => writeFile(androidAutoCatalogPath, catalogJson, "utf8"))
+        .catch(() => undefined);
+
+    return catalogExportTask;
+}
+
+export function exportAndroidAutoCatalog(
+    playList: IMusic.IMusicItem[],
+    currentMusic?: IMusic.IMusicItem | null,
+) {
+    lastPlayList = playList;
+    lastCurrentMusic = currentMusic ?? null;
+    hasCatalogSnapshot = true;
+    return writeAndroidAutoCatalog();
+}
+
+export function exportAndroidAutoPlaybackState(playbackState?: string | null) {
+    lastPlaybackState = playbackState ?? null;
+    return hasCatalogSnapshot ? writeAndroidAutoCatalog() : Promise.resolve();
+}


### PR DESCRIPTION
## 变更内容
- 增加 Android Auto 使用的 MediaBrowserService 和 automotive app 声明
- 导出当前播放列表、当前歌曲、播放状态和封面信息，供车机端浏览和展示
- 将车机端播放、暂停、切歌、进度跳转等控制指令转交给 TrackPlayer 后台服务处理

## 说明
这个实现主要是让 MusicFree 可以直接出现在 Android Auto 的媒体应用列表中，并支持在车机端查看当前列表、播放歌曲和控制播放。

## 测试
- 本地使用 Gradle 构建 release APK 通过
- 使用 Android Auto Desktop Head Unit 验证列表浏览、播放、切歌、元数据和封面展示
- 验证车机控制指令不再依赖先手动打开主界面