### PR TITLE
feat: 导航栏设置为沉浸式

### DIFF
--- a/android/app/src/main/java/fun/upup/musicfree/MainActivity.kt
+++ b/android/app/src/main/java/fun/upup/musicfree/MainActivity.kt
@@ -7,6 +7,11 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 import android.os.Bundle
+import androidx.core.view.WindowCompat
+import android.graphics.Color
+import android.os.Build
+import android.view.View
+import android.view.WindowManager
 
 class MainActivity : ReactActivity() {
 
@@ -27,5 +32,16 @@ class MainActivity : ReactActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
       SplashScreenManager.registerOnActivity(this)
       super.onCreate(null);
+      WindowCompat.setDecorFitsSystemWindows(window, false)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          window.isNavigationBarContrastEnforced = false
+      }
+      window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION)
+      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+      var systemUiVisibility = window.decorView.systemUiVisibility
+      systemUiVisibility =
+          systemUiVisibility or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+      window.decorView.systemUiVisibility = systemUiVisibility
+      window.navigationBarColor = Color.TRANSPARENT
   }
 }


### PR DESCRIPTION
feat: 导航栏设置为沉浸式
<img width="276" height="597" alt="image" src="https://github.com/user-attachments/assets/0833f21b-c406-40b0-8731-aef9dbd0d3e9" />
